### PR TITLE
Use walnascar branch of meta chromium test

### DIFF
--- a/.github/workflows/chromium.yml
+++ b/.github/workflows/chromium.yml
@@ -54,5 +54,5 @@ jobs:
          git clone $GH_URL
          git -C meta-browser checkout $GH_REV
          # clone the test repo
-         git clone https://github.com/brightsign/meta-chromium-test.git
+         git clone -b walnascar https://github.com/brightsign/meta-chromium-test.git
          ./meta-chromium-test/scripts/build.sh ${{ matrix.yocto_version}} ${{ matrix.arch }} ${{ matrix.chromium_version }} ${{ matrix.libc_flavour}}


### PR DESCRIPTION
Chromium132 can only compile with compiler toolset comes with walnascar. Use walnascar branch of meta-chromium-test with Chromium132. 

Chromium138 will use latest master for meta-oe, poky and meta-clang