### PR TITLE
electron; Build recipe for Electron 37.1.0 OS-19689

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -1,4 +1,4 @@
-name: Chromium build- and smoke-test
+name: Electron build- and smoke-test
 
 on:
   workflow_dispatch:
@@ -16,9 +16,9 @@ on:
       - master
     paths:
       - 'meta-chromium/recipes-browser/chromium/files/**'
-      - 'meta-chromium/recipes-browser/chromium/chromium*'
+      - 'meta-chromium/recipes-browser/chromium/electron*'
       - 'meta-chromium/recipes-browser/chromium/gn*'
-      - '.github/workflows/chromium.yml'
+      - '.github/workflows/electron.yml'
 
 permissions:
   contents: read
@@ -31,8 +31,8 @@ jobs:
     strategy:
       matrix:
         yocto_version: [master]
-        browser_version: [ozone-wayland, x11]
-        browser: [chromium]
+        browser_version: [ozone-wayland]
+        browser: [electron]
         libc_flavour: [glibc]
         arch: [arm, aarch64, x86-64]
     runs-on: [self-hosted, chromium]

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         yocto_version: [master]
-        browser_version: [ozone-wayland]
+        browser_version: [ozone-wayland, ozone-x11]
         browser: [electron]
         libc_flavour: [glibc]
         arch: [arm, aarch64, x86-64]

--- a/meta-chromium/recipes-browser/chromium/electron-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/electron-gn.inc
@@ -1,0 +1,75 @@
+require electron.inc
+
+# Override the compile target for Electron
+do_compile() {
+	ninja -v ${PARALLEL_MAKE} electron
+}
+do_compile[progress] = "outof:^\[(\d+)/(\d+)\]\s+"
+
+# Override the install task for Electron-specific installation
+do_install() {
+	install -d ${D}${bindir}
+	install -d ${D}${libdir}/electron
+	install -d ${D}${libdir}/electron/locales
+	install -d ${D}${libdir}/electron/resources
+
+	install -m 0755 electron ${D}${libdir}/electron/electron
+	ln -s ${libdir}/electron/electron ${D}${bindir}/electron
+	install -m 0644 resources/default_app.asar ${D}${libdir}/electron/resources/default_app.asar
+	install -m 0644 *.bin ${D}${libdir}/electron/
+	install -m 0644 icudtl.dat ${D}${libdir}/electron/icudtl.dat
+
+	# Chromium *.pak files
+	install -m 0644 chrome_*.pak ${D}${libdir}/electron/
+	install -m 0644 resources.pak ${D}${libdir}/electron/resources.pak
+
+	# Locales.
+	install -m 0644 locales/*.pak ${D}${libdir}/electron/locales/
+
+	install -m 0755 libffmpeg.so ${D}${libdir}/electron/
+
+	# ANGLE.
+	if [ -e libEGL.so ]; then
+		install -m 0644 libEGL.so ${D}${libdir}/electron/
+		install -m 0644 libGLESv2.so ${D}${libdir}/electron/
+	fi
+
+	# libvulkan (for ANGLE).
+	if [ -e libvulkan.so.1 ]; then
+		install -m 0644 libvulkan.so.1 ${D}${libdir}/electron/
+	fi
+
+	# Swiftshader VK.
+	if [ -e libvk_swiftshader.so ]; then
+		install -m 0644 libvk_swiftshader.so ${D}${libdir}/electron/
+		# This is needed for ANGLE to find libvk_swiftshader.so.
+		install -m 0644 vk_swiftshader_icd.json ${D}${libdir}/electron/
+	fi
+
+	if [ -n "${@bb.utils.contains('PACKAGECONFIG', 'component-build', 'component-build', '', d)}" ]; then
+		install -m 0755 *.so ${D}${libdir}/electron/
+	fi
+
+	# When building chromium with use_system_minigbm=false,
+	# libminigbm.so does not seem to get linked in statically.
+	# So we simply check whether it exists in all cases and ship it.
+	if [ -e libminigbm.so ]; then
+		install -m 0755 libminigbm.so ${D}${libdir}/electron/
+	fi
+}
+
+# Electron-specific package files
+FILES:${PN} = " \
+        ${bindir}/electron \
+        ${libdir}/electron/* \
+"
+
+PACKAGE_DEBUG_SPLIT_STYLE = "debug-without-src"
+
+# There is no need to ship empty -dev packages.
+ALLOW_EMPTY:${PN}-dev = "0"
+
+# ERROR: QA Issue: lib32-chromium-ozone-wayland: ELF binary /usr/bin/chromium has relocations in .text [textrel]
+INSANE_SKIP:${PN}:append:x86 = "textrel"
+
+PACKAGECONFIG:append = " proprietary-codecs"

--- a/meta-chromium/recipes-browser/chromium/electron-ozone-nexus.bb
+++ b/meta-chromium/recipes-browser/chromium/electron-ozone-nexus.bb
@@ -1,0 +1,37 @@
+require electron-gn.inc
+
+# Only Broadcom STB chips have have Nexus and Bitbake will complain
+# when building for anything else without something like this.
+COMPATIBLE_MACHINE = "^brcmstb$"
+
+RPROVIDES:${PN} = "electron"
+
+SRC_URI += "\
+	file://remove_dri.patch \
+"
+
+DEPENDS += "\
+        libnotify \
+        at-spi2-atk \
+        libffi \
+        nexus \
+"
+
+GN_ARGS += "\
+        ${PACKAGECONFIG_CONFARGS} \
+        use_ozone=true \
+        ozone_auto_platforms=false \
+        ozone_platform_nexus=true \
+        use_xkbcommon=true \
+        use_system_minigbm=true \
+        use_system_libffi=true \
+        use_gtk=false \
+        use_gio=false \
+        use_lttng=true \
+        use_bundled_fontconfig=false \
+        override_electron_version="${PV}" \
+        import("//electron/build/args/release.gn") \
+"
+
+# The electron binary must always be started with those arguments.
+CHROMIUM_EXTRA_ARGS:append = " --ozone-platform=nexus"

--- a/meta-chromium/recipes-browser/chromium/electron-ozone-wayland.bb
+++ b/meta-chromium/recipes-browser/chromium/electron-ozone-wayland.bb
@@ -1,0 +1,46 @@
+require electron-gn.inc
+
+RPROVIDES:${PN} = "electron"
+
+REQUIRED_DISTRO_FEATURES = "wayland"
+
+DEPENDS += "\
+        libnotify \
+        at-spi2-atk \
+        virtual/egl \
+        wayland \
+        wayland-native \
+        libffi \
+        gtk+3 \
+"
+
+GN_ARGS += "\
+        ${PACKAGECONFIG_CONFARGS} \
+        use_ozone=true \
+        ozone_auto_platforms=false \
+        ozone_platform_headless=true \
+        ozone_platform_wayland=true \
+        use_system_wayland_scanner=false \
+        use_xkbcommon=true \
+        use_system_libwayland=false \
+        use_system_minigbm=true \
+        use_system_libffi=true \
+        use_bundled_fontconfig=false \
+        override_electron_version="${PV}" \
+        import("//electron/build/args/release.gn") \
+"
+
+# The electron binary must always be started with those arguments.
+CHROMIUM_EXTRA_ARGS:append = " --ozone-platform=wayland"
+
+# Angle is not used by Wayland yet, but it was still built. It wasn't a problem
+# until wayland-protocols were updated to 1.20 in newest yocto releases, which
+# changed the implementation of the wayland-scanner tool. That tool uses a new
+# API, which is not part of older wayland-protocols. And given ANGLE includes
+# libwayland headers from //third_party/wayland instead of relaying on the
+# system ones, that results in undeclared methods.
+# TODO(msisov): remove this once Chromium's //third_party/wayland is updated
+# to >=1.20. This tracks https://crbug.com/1359189
+GN_ARGS += "\
+        angle_use_wayland=false \
+"

--- a/meta-chromium/recipes-browser/chromium/electron-ozone-x11.bb
+++ b/meta-chromium/recipes-browser/chromium/electron-ozone-x11.bb
@@ -1,0 +1,50 @@
+require electron-gn.inc
+
+RPROVIDES:${PN} = "electron"
+
+REQUIRED_DISTRO_FEATURES = "x11"
+
+DEPENDS += "\
+        libnotify \
+        libx11 \
+        libxcomposite \
+        libxcursor \
+        libxdamage \
+        libxext \
+        libxfixes \
+        libxi \
+        libxrandr \
+        libxrender \
+        libxscrnsaver \
+        libxtst \
+        at-spi2-atk \
+        virtual/egl \
+        libffi \
+        gtk+3 \
+"
+
+# Loaded at runtime.
+# https://source.chromium.org/chromium/chromium/src/+/main:ui/gfx/x/xlib_support.cc
+RDEPENDS:${PN} += "libx11-xcb"
+
+GN_ARGS += "\
+        ${PACKAGECONFIG_CONFARGS} \
+        use_ozone=true \
+        ozone_auto_platforms=false \
+        ozone_platform_headless=true \
+        ozone_platform_wayland=false \
+        ozone_platform_x11=true \
+        use_xkbcommon=true \
+        use_system_minigbm=true \
+        use_system_libffi=true \
+        use_bundled_fontconfig=false \
+        override_electron_version="${PV}" \
+        import("//electron/build/args/release.gn") \
+"
+
+# The electron binary must always be started with those arguments.
+CHROMIUM_EXTRA_ARGS:append = " --ozone-platform=x11"
+
+# Compatibility glue while we have both electron-ozone-x11 and
+# electron-ozone-wayland recipes.
+PROVIDES = "electron"

--- a/meta-chromium/recipes-browser/chromium/electron.inc
+++ b/meta-chromium/recipes-browser/chromium/electron.inc
@@ -1,0 +1,42 @@
+# Inherit from chromium-gn.inc to get all shared configuration
+require chromium-gn.inc
+
+# Electron-specific metadata
+DESCRIPTION = "Electron is an open-source project that aims to enable building cross-platform desktop apps with JavaScript, HTML, and CSS"
+HOMEPAGE = "https://www.electronjs.org/"
+
+# Override CVE product to include Electron and Node.js
+CVE_PRODUCT = "chromium:chromium google:chrome electronjs:electron nodejs:node.js"
+
+# Electron version - override the Chromium version
+PV = "37.1.0-bs.alpha2"
+
+# Electron-specific source - replace Chromium source with Electron source
+SRC_URI = "https://electron-ci-public-artifact-bucket.s3.amazonaws.com/v${PV}/v${PV}.tar.xz"
+SRC_URI[sha256sum] = "4921ad086f4c7be4374cd6b1e18a22c0f90a58c6b2253b6e90f16ae88c9cfb12"
+S = "${UNPACKDIR}/src"
+
+SRC_URI += " \
+    file://0001-electron-fix-js2c-toolchain-for-Yocto-cross-compilat.patch \
+    file://0002-fix-Remove-X11-dependencies.patch \
+    file://0003-fix-Electron-yocto-build-problems.patch \
+"
+
+# Non-specific patches.
+SRC_URI += "\
+    file://0001-Drop-GN-compiler-settings-conflicting-with-OE.patch \
+    file://0002-v8-qemu-wrapper.patch \
+    file://0003-wrapper-extra-flags.patch \
+    file://0004-Delete-compiler-options-not-available-in-release-ver.patch \
+    file://0005-avoid-link-latomic-failure-on-CentOS-8-host.patch \
+    file://0006-Don-t-pass-unknown-LLVM-options.patch \
+    file://0007-Fix-constexpr-variable-must-be-initialized-by-a-cons.patch \
+    file://0008-Use-the-correct-path-to-libclang_rt.builtins.a.patch \
+    file://0009-Adjust-the-Rust-build-to-our-needs.patch \
+    file://0010-Don-t-require-profiler_builtins.rlib.patch \
+    file://0011-fix-check_version-Only-compare-node.js-major-version.patch \
+    file://0012-chromium-fix-v4l2-compiler-error-on-arm.patch \
+"
+
+# ARM/AArch64-specific patches.
+SRC_URI:append:aarch64 = "${@bb.utils.contains('TUNE_FEATURES', 'crypto', '', ' file://arm/0001-Fix-AES-crypto-SIGILL-on-rpi4-64.patch', d)}"

--- a/meta-chromium/recipes-browser/chromium/electron.inc
+++ b/meta-chromium/recipes-browser/chromium/electron.inc
@@ -39,4 +39,5 @@ SRC_URI += "\
 "
 
 # ARM/AArch64-specific patches.
-SRC_URI:append:aarch64 = "${@bb.utils.contains('TUNE_FEATURES', 'crypto', '', ' file://arm/0001-Fix-AES-crypto-SIGILL-on-rpi4-64.patch', d)}"
+# Note: 0001-Fix-AES-crypto-SIGILL-on-rpi4-64.patch is already included in Electron source
+# SRC_URI:append:aarch64 = "${@bb.utils.contains('TUNE_FEATURES', 'crypto', '', ' file://arm/0001-Fix-AES-crypto-SIGILL-on-rpi4-64.patch', d)}"

--- a/meta-chromium/recipes-browser/chromium/files/0001-electron-fix-js2c-toolchain-for-Yocto-cross-compilat.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0001-electron-fix-js2c-toolchain-for-Yocto-cross-compilat.patch
@@ -1,0 +1,37 @@
+From eb0e4dad4045362cc2cb2b16296f8df79a89c1e9 Mon Sep 17 00:00:00 2001
+From: Caner Altinbasak <cal@brightsign.biz>
+Date: Tue, 29 Jul 2025 00:00:00 +0000
+Subject: [PATCH] electron: fix js2c toolchain for Yocto cross-compilation
+
+The electron js2c toolchain selection logic doesn't properly handle
+Yocto cross-compilation environments where host tools need to be built
+with the host toolchain rather than the target toolchain.
+
+This patch forces the electron_js2c_toolchain to use host_toolchain
+in cross-compilation scenarios to ensure node_js2c can execute on
+the build machine.
+
+Upstream-Status: Inappropriate [OE-specific]
+---
+ electron/build/js2c_toolchain.gni | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/electron/build/js2c_toolchain.gni b/electron/build/js2c_toolchain.gni
+index b56590857c..b754143aba 100644
+--- a/electron/build/js2c_toolchain.gni
++++ b/electron/build/js2c_toolchain.gni
+@@ -6,6 +6,11 @@ declare_args() {
+   electron_js2c_toolchain = ""
+ }
+ 
++# Force host toolchain for Yocto cross-compilation
++if (electron_js2c_toolchain == "" && defined(host_toolchain)) {
++  electron_js2c_toolchain = host_toolchain
++}
++
+ if (electron_js2c_toolchain == "") {
+   if (current_os == host_os && current_cpu == host_cpu) {
+     # This is not a cross-compile, so build the snapshot with the current
+-- 
+2.39.5
+

--- a/meta-chromium/recipes-browser/chromium/files/0002-fix-Remove-X11-dependencies.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0002-fix-Remove-X11-dependencies.patch
@@ -1,0 +1,74 @@
+From a1b544e401fee3aff490de23c0c4749d797d4448 Mon Sep 17 00:00:00 2001
+From: Caner Altinbasak <cal@brightsign.biz>
+Date: Tue, 29 Jul 2025 13:35:16 +0100
+Subject: [PATCH] fix: Remove X11 dependencies
+
+Electron introduces X11 dependencies in wayland ozone platform backend.
+This is undesired behaviour.
+
+Upstream-Status: Inappropriate
+---
+ electron/BUILD.gn                                         | 8 +++++---
+ .../shell/browser/api/electron_api_desktop_capturer.cc    | 2 ++
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/electron/BUILD.gn b/electron/BUILD.gn
+index fe4fb706f5..3308a5bb92 100644
+--- a/electron/BUILD.gn
++++ b/electron/BUILD.gn
+@@ -637,7 +637,6 @@ source_set("electron_lib") {
+     }
+   }
+   if (is_linux) {
+-    libs = [ "xshmfence" ]
+     deps += [
+       ":electron_gtk_stubs",
+       ":libnotify_loader",
+@@ -647,19 +646,22 @@ source_set("electron_lib") {
+       "//device/bluetooth",
+       "//third_party/crashpad/crashpad/client",
+       "//ui/base/ime/linux",
+-      "//ui/events/devices/x11",
+-      "//ui/events/platform/x11",
+       "//ui/gtk:gtk_config",
+       "//ui/linux:linux_ui",
+       "//ui/linux:linux_ui_factory",
+       "//ui/wm",
+     ]
+     if (ozone_platform_x11) {
++      libs = [ "xshmfence" ]
+       sources += filenames.lib_sources_linux_x11
+       public_deps += [
+         "//ui/base/x",
+         "//ui/ozone/platform/x11",
+       ]
++      deps += [
++        "//ui/events/devices/x11",
++        "//ui/events/platform/x11",
++      ]
+     }
+     configs += [ ":gio_unix" ]
+     defines += [
+diff --git a/electron/shell/browser/api/electron_api_desktop_capturer.cc b/electron/shell/browser/api/electron_api_desktop_capturer.cc
+index d0b3f40b5d..e43bd39199 100644
+--- a/electron/shell/browser/api/electron_api_desktop_capturer.cc
++++ b/electron/shell/browser/api/electron_api_desktop_capturer.cc
+@@ -49,6 +49,7 @@
+ 
+ namespace {
+ #if BUILDFLAG(IS_LINUX)
++#if BUILDFLAG(IS_OZONE_X11)
+ // Private function in ui/base/x/x11_display_util.cc
+ base::flat_map<x11::RandR::Output, int> GetMonitors(
+     std::pair<uint32_t, uint32_t> version,
+@@ -143,6 +144,7 @@ base::flat_map<int32_t, uint32_t> MonitorAtomIdToDisplayId() {
+   return monitor_atom_to_display;
+ }
+ #endif
++#endif
+ 
+ std::unique_ptr<ThumbnailCapturer> MakeWindowCapturer() {
+ #if BUILDFLAG(IS_MAC)
+-- 
+2.39.5
+

--- a/meta-chromium/recipes-browser/chromium/files/0003-fix-Electron-yocto-build-problems.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0003-fix-Electron-yocto-build-problems.patch
@@ -1,17 +1,30 @@
-From 1fe03c3e5f346865c4b1a5ca4fc5b3b0c64d6793 Mon Sep 17 00:00:00 2001
+From e1d41130d98f66b0a48e07bf8d76737caee3d65b Mon Sep 17 00:00:00 2001
 From: Caner Altinbasak <cal@brightsign.biz>
 Date: Tue, 29 Jul 2025 17:21:47 +0100
 Subject: [PATCH] fix: Electron yocto build problems
 
 Upstream-Status: Inappropriate
 ---
+ content/zygote/zygote_linux.cc                |  1 +
  electron/shell/browser/native_window_views.cc | 24 ++++++++++---------
  electron/shell/browser/native_window_views.h  |  4 ++--
  .../browser/osr/osr_host_display_client.cc    |  2 +-
  .../browser/osr/osr_host_display_client.h     |  2 +-
  electron/shell/browser/ui/gtk/menu_util.cc    |  7 ++++++
- 5 files changed, 24 insertions(+), 15 deletions(-)
+ 6 files changed, 25 insertions(+), 15 deletions(-)
 
+diff --git a/content/zygote/zygote_linux.cc b/content/zygote/zygote_linux.cc
+index 003169cf7d..07a5f855b1 100644
+--- a/content/zygote/zygote_linux.cc
++++ b/content/zygote/zygote_linux.cc
+@@ -13,6 +13,7 @@
+ #include <sys/socket.h>
+ #include <sys/types.h>
+ #include <sys/wait.h>
++#include <sys/prctl.h>
+ #include <grp.h>
+ 
+ #include <tuple>
 diff --git a/electron/shell/browser/native_window_views.cc b/electron/shell/browser/native_window_views.cc
 index 3b18f05042..25cdaa4027 100644
 --- a/electron/shell/browser/native_window_views.cc

--- a/meta-chromium/recipes-browser/chromium/files/0003-fix-Electron-yocto-build-problems.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0003-fix-Electron-yocto-build-problems.patch
@@ -1,0 +1,212 @@
+From 1fe03c3e5f346865c4b1a5ca4fc5b3b0c64d6793 Mon Sep 17 00:00:00 2001
+From: Caner Altinbasak <cal@brightsign.biz>
+Date: Tue, 29 Jul 2025 17:21:47 +0100
+Subject: [PATCH] fix: Electron yocto build problems
+
+Upstream-Status: Inappropriate
+---
+ electron/shell/browser/native_window_views.cc | 24 ++++++++++---------
+ electron/shell/browser/native_window_views.h  |  4 ++--
+ .../browser/osr/osr_host_display_client.cc    |  2 +-
+ .../browser/osr/osr_host_display_client.h     |  2 +-
+ electron/shell/browser/ui/gtk/menu_util.cc    |  7 ++++++
+ 5 files changed, 24 insertions(+), 15 deletions(-)
+
+diff --git a/electron/shell/browser/native_window_views.cc b/electron/shell/browser/native_window_views.cc
+index 3b18f05042..25cdaa4027 100644
+--- a/electron/shell/browser/native_window_views.cc
++++ b/electron/shell/browser/native_window_views.cc
+@@ -333,6 +333,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
+   if (parent)
+     SetParentWindow(parent);
+ 
++#if BUILDFLAG(IS_OZONE_X11)
+   if (x11_util::IsX11()) {
+     // Before the window is mapped the SetWMSpecState can not work, so we have
+     // to manually set the _NET_WM_STATE.
+@@ -365,6 +366,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
+                     window_type);
+   }
+ #endif
++#endif
+ 
+ #if BUILDFLAG(IS_WIN)
+   if (!has_frame()) {
+@@ -478,7 +480,7 @@ NativeWindowViews::~NativeWindowViews() {
+ }
+ 
+ void NativeWindowViews::SetGTKDarkThemeEnabled(bool use_dark_theme) {
+-#if BUILDFLAG(IS_LINUX)
++#if BUILDFLAG(IS_LINUX) && BUILDFLAG(IS_OZONE_X11)
+   if (x11_util::IsX11()) {
+     const std::string color = use_dark_theme ? "dark" : "light";
+     auto* connection = x11::Connection::Get();
+@@ -566,7 +568,7 @@ void NativeWindowViews::Show() {
+ 
+   NotifyWindowShow();
+ 
+-#if BUILDFLAG(IS_LINUX)
++#if BUILDFLAG(IS_LINUX) && BUILDFLAG(IS_OZONE_X11)
+   if (global_menu_bar_)
+     global_menu_bar_->OnWindowMapped();
+ 
+@@ -582,7 +584,7 @@ void NativeWindowViews::ShowInactive() {
+ 
+   NotifyWindowShow();
+ 
+-#if BUILDFLAG(IS_LINUX)
++#if BUILDFLAG(IS_LINUX) && BUILDFLAG(IS_OZONE_X11)
+   if (global_menu_bar_)
+     global_menu_bar_->OnWindowMapped();
+ 
+@@ -601,7 +603,7 @@ void NativeWindowViews::Hide() {
+ 
+   NotifyWindowHide();
+ 
+-#if BUILDFLAG(IS_LINUX)
++#if BUILDFLAG(IS_LINUX) && BUILDFLAG(IS_OZONE_X11)
+   if (global_menu_bar_)
+     global_menu_bar_->OnWindowUnmapped();
+ #endif
+@@ -632,7 +634,7 @@ bool NativeWindowViews::IsVisible() const {
+ bool NativeWindowViews::IsEnabled() const {
+ #if BUILDFLAG(IS_WIN)
+   return ::IsWindowEnabled(GetAcceleratedWidget());
+-#elif BUILDFLAG(IS_LINUX)
++#elif BUILDFLAG(IS_LINUX) && BUILDFLAG(IS_OZONE_X11)
+   if (x11_util::IsX11())
+     return !event_disabler_.get();
+   NOTIMPLEMENTED();
+@@ -669,7 +671,7 @@ void NativeWindowViews::SetEnabledInternal(bool enable) {
+ 
+ #if BUILDFLAG(IS_WIN)
+   ::EnableWindow(GetAcceleratedWidget(), enable);
+-#else
++#elif BUILDFLAG(IS_OZONE_X11)
+   if (x11_util::IsX11()) {
+     views::DesktopWindowTreeHostPlatform* tree_host =
+         views::DesktopWindowTreeHostLinux::GetHostForWidget(
+@@ -1001,7 +1003,7 @@ bool NativeWindowViews::MoveAbove(const std::string& sourceId) {
+   ::SetWindowPos(GetAcceleratedWidget(), GetWindow(otherWindow, GW_HWNDPREV), 0,
+                  0, 0, 0,
+                  SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+-#else
++#elif BUILDFLAG(IS_OZONE_X11)
+   if (x11_util::IsX11()) {
+     if (!IsWindowValid(static_cast<x11::Window>(id.id)))
+       return false;
+@@ -1023,7 +1025,7 @@ void NativeWindowViews::MoveTop() {
+   ::SetWindowPos(GetAcceleratedWidget(), HWND_TOP, pos.x(), pos.y(),
+                  size.width(), size.height(),
+                  SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+-#else
++#elif BUILDFLAG(IS_OZONE_X11)
+   if (x11_util::IsX11())
+     electron::MoveWindowToForeground(
+         static_cast<x11::Window>(GetAcceleratedWidget()));
+@@ -1365,7 +1367,7 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
+   } else {
+     SetForwardMouseMessages(forward);
+   }
+-#else
++#elif BUILDFLAG(IS_OZONE_X11)
+   if (x11_util::IsX11()) {
+     auto* connection = x11::Connection::Get();
+     if (ignore) {
+@@ -1431,7 +1433,7 @@ bool NativeWindowViews::IsFocusable() const {
+ }
+ 
+ void NativeWindowViews::SetMenu(ElectronMenuModel* menu_model) {
+-#if BUILDFLAG(IS_LINUX)
++#if BUILDFLAG(IS_LINUX) && BUILDFLAG(IS_OZONE_X11)
+   // Remove global menu bar.
+   if (global_menu_bar_ && menu_model == nullptr) {
+     global_menu_bar_.reset();
+@@ -1487,7 +1489,7 @@ void NativeWindowViews::SetMenu(ElectronMenuModel* menu_model) {
+ void NativeWindowViews::SetParentWindow(NativeWindow* parent) {
+   NativeWindow::SetParentWindow(parent);
+ 
+-#if BUILDFLAG(IS_LINUX)
++#if BUILDFLAG(IS_LINUX) && BUILDFLAG(IS_OZONE_X11)
+   if (x11_util::IsX11()) {
+     auto* connection = x11::Connection::Get();
+     connection->SetProperty(
+diff --git a/electron/shell/browser/native_window_views.h b/electron/shell/browser/native_window_views.h
+index 7e192ff817..042bb5ee25 100644
+--- a/electron/shell/browser/native_window_views.h
++++ b/electron/shell/browser/native_window_views.h
+@@ -28,7 +28,7 @@
+ 
+ namespace electron {
+ 
+-#if BUILDFLAG(IS_LINUX)
++#if BUILDFLAG(IS_LINUX) && BUILDFLAG(IS_OZONE_X11)
+ class GlobalMenuBarX11;
+ #endif
+ 
+@@ -262,7 +262,7 @@ class NativeWindowViews : public NativeWindow,
+   // events from resizing the window.
+   extensions::SizeConstraints old_size_constraints_;
+ 
+-#if BUILDFLAG(IS_LINUX)
++#if BUILDFLAG(IS_LINUX) && BUILDFLAG(IS_OZONE_X11)
+   std::unique_ptr<GlobalMenuBarX11> global_menu_bar_;
+ #endif
+ 
+diff --git a/electron/shell/browser/osr/osr_host_display_client.cc b/electron/shell/browser/osr/osr_host_display_client.cc
+index 8f316f0449..b037fa8bf8 100644
+--- a/electron/shell/browser/osr/osr_host_display_client.cc
++++ b/electron/shell/browser/osr/osr_host_display_client.cc
+@@ -95,7 +95,7 @@ void OffScreenHostDisplayClient::CreateLayeredWindowUpdater(
+   layered_window_updater_->SetActive(active_);
+ }
+ 
+-#if BUILDFLAG(IS_LINUX) && !BUILDFLAG(IS_CHROMEOS)
++#if BUILDFLAG(IS_LINUX) && BUILDFLAG(IS_OZONE_X11)
+ void OffScreenHostDisplayClient::DidCompleteSwapWithNewSize(
+     const gfx::Size& size) {}
+ #endif
+diff --git a/electron/shell/browser/osr/osr_host_display_client.h b/electron/shell/browser/osr/osr_host_display_client.h
+index e95eb43bd1..0f4e0386d3 100644
+--- a/electron/shell/browser/osr/osr_host_display_client.h
++++ b/electron/shell/browser/osr/osr_host_display_client.h
+@@ -74,7 +74,7 @@ class OffScreenHostDisplayClient : public viz::HostDisplayClient {
+       mojo::PendingReceiver<viz::mojom::LayeredWindowUpdater> receiver)
+       override;
+ 
+-#if BUILDFLAG(IS_LINUX) && !BUILDFLAG(IS_CHROMEOS)
++#if BUILDFLAG(IS_LINUX) && BUILDFLAG(IS_OZONE_X11)
+   void DidCompleteSwapWithNewSize(const gfx::Size& size) override;
+ #endif
+ 
+diff --git a/electron/shell/browser/ui/gtk/menu_util.cc b/electron/shell/browser/ui/gtk/menu_util.cc
+index 76bc5862f6..28204fab5a 100644
+--- a/electron/shell/browser/ui/gtk/menu_util.cc
++++ b/electron/shell/browser/ui/gtk/menu_util.cc
+@@ -18,8 +18,11 @@
+ #include "ui/base/accelerators/menu_label_accelerator_util_linux.h"
+ #include "ui/base/models/image_model.h"
+ #include "ui/base/models/menu_model.h"
++#include "ui/base/ozone_buildflags.h"
+ #include "ui/events/event_constants.h"
++#if BUILDFLAG(IS_OZONE_X11)
+ #include "ui/events/keycodes/keyboard_code_conversion_x.h"
++#endif
+ #include "ui/ozone/public/ozone_platform.h"
+ 
+ namespace electron::gtkui {
+@@ -42,7 +45,11 @@ int EventFlagsFromGdkState(guint state) {
+ guint GetGdkKeyCodeForAccelerator(const ui::Accelerator& accelerator) {
+   // The second parameter is false because accelerator keys are expressed in
+   // terms of the non-shift-modified key.
++#if BUILDFLAG(IS_OZONE_X11)
+   return XKeysymForWindowsKeyCode(accelerator.key_code(), false);
++#else
++  return 0;
++#endif
+ }
+ 
+ GdkModifierType GetGdkModifierForAccelerator(
+-- 
+2.39.5
+

--- a/meta-chromium/recipes-browser/chromium/files/remove_dri.patch
+++ b/meta-chromium/recipes-browser/chromium/files/remove_dri.patch
@@ -1,0 +1,22 @@
+diff --git a/content/gpu/BUILD.gn b/content/gpu/BUILD.gn
+index 93559f6092c7a..f257fa50077e9 100644
+--- a/content/gpu/BUILD.gn
++++ b/content/gpu/BUILD.gn
+@@ -141,6 +141,5 @@ target(link_target_type, "gpu_sources") {
+   # Use DRI on desktop Linux builds.
+   if (current_cpu != "s390x" && current_cpu != "ppc64" && is_linux &&
+       !is_castos) {
+-    configs += [ "//build/config/linux/dri" ]
+   }
+ }
+diff --git a/media/gpu/sandbox/BUILD.gn b/media/gpu/sandbox/BUILD.gn
+index cfcb7fa80ef89..8d149450b2116 100644
+--- a/media/gpu/sandbox/BUILD.gn
++++ b/media/gpu/sandbox/BUILD.gn
+@@ -33,6 +33,5 @@ source_set("sandbox") {
+   if (current_cpu != "s390x" && current_cpu != "ppc64" && is_linux &&
+       !is_castos) {
+     # For DRI_DRIVER_DIR.
+-    configs += [ "//build/config/linux/dri" ]
+   }
+ }


### PR DESCRIPTION
Added an electron build recipe and supplementary files. Electron recipes include Chromium recipes and override the necessary parts like do_compile, do_configure.